### PR TITLE
feat: add verbose flag and improve wireguard configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,11 @@
       "Bash(git add:*)",
       "Bash(gofmt:*)",
       "Bash(go vet:*)",
-      "Bash(go get:*)"
+      "Bash(go get:*)",
+      "Bash(go list:*)",
+      "Bash(go clean:*)",
+      "Bash(rg:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   }

--- a/example-wg0.conf
+++ b/example-wg0.conf
@@ -1,9 +1,10 @@
 [Interface]
-PrivateKey = 4Jks8JdqwJPRshKdmXpUHklKxvHBe7y5cZn8Xy9T/Gw=
-Address = 10.0.0.2/24
+PrivateKey = MFUi5Ifm+AoCB83PFlv4MIbT+gUUOCATAR1o+qJnuVc=
+Address = 10.2.0.2/32
+DNS = 8.8.8.8
 
 [Peer]
-PublicKey = /TOE4TKtAqVsePRVR+5AA43HkAK5DSntkOCO7nYq5xU=
-Endpoint = demo.wireguard.com:51820
+PublicKey = lBKGHDRS3JrAJCFHJLe4cqhMnaaymBpKAhTxOFb8gT8=
 AllowedIPs = 0.0.0.0/0
+Endpoint = 192.168.64.6:51820
 PersistentKeepalive = 25

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func printUsage() {
 
 	help += "\033[33mOPTIONS:\033[0m\n"
 	help += "    --config=<path>    Path to WireGuard configuration file\n"
+	help += "    --verbose          Show verbose output\n"
 	help += "    --help             Show this help message\n"
 	help += "    --version          Show version information\n\n"
 
@@ -69,9 +70,11 @@ func main() {
 	var configPath string
 	var showHelp bool
 	var showVersion bool
+	var verbose bool
 	flag.StringVar(&configPath, "config", "", "Path to WireGuard configuration file")
 	flag.BoolVar(&showHelp, "help", false, "Show help message")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
+	flag.BoolVar(&verbose, "verbose", false, "Show verbose output")
 	flag.Usage = printUsage
 	flag.Parse()
 
@@ -110,7 +113,7 @@ func main() {
 	}
 
 	// Initialize WireGuard with memory-based TUN
-	wg, err := NewWireGuardProxy(config, netStack)
+	wg, err := NewWireGuardProxy(config, netStack, verbose)
 	if err != nil {
 		log.Fatalf("Failed to initialize WireGuard: %v", err)
 	}
@@ -181,6 +184,8 @@ func main() {
 			}
 			log.Fatalf("Child process error: %v", err)
 		}
+		// Exit cleanly when child process completes successfully
+		os.Exit(0)
 	case sig := <-sigChan:
 		// Forward signal to child process
 		if cmd.Process != nil {
@@ -188,5 +193,6 @@ func main() {
 		}
 		// Wait for child to exit
 		<-done
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Bugfix: Fix hex encoding for WireGuard keys

Also:
- Add --verbose flag to control logging output
- Update example configuration with new network settings
- Add clean exit handling for child processes
