### PR TITLE
fix: version outputs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,9 @@
       "Bash(go list:*)",
       "Bash(go clean:*)",
       "Bash(rg:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
     ],
     "deny": []
   }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func printUsage() {
 	help := fmt.Sprintf(`
 ╦ ╦┬─┐┌─┐┌─┐╔═╗┬ ┬┌─┐┬─┐┌┬┐
 ║║║├┬┘├─┤├─┘║ ╦│ │├─┤├┬┘ ││
-╚╩╝┴└─┴ ┴┴  ╚═╝└─┘┴ ┴┴└──┴┘ v%s
+╚╩╝┴└─┴ ┴┴  ╚═╝└─┘┴ ┴┴└──┴┘ %s
 
 🔒 Userspace WireGuard proxy for transparent network tunneling
 
@@ -136,7 +136,7 @@ func main() {
 	defer ipcServer.Stop()
 
 	// Show startup message
-	fmt.Printf("\n\033[32m✓\033[0m WrapGuard v%s initialized\n", Version)
+	fmt.Printf("\n\033[32m✓\033[0m WrapGuard %s initialized\n", Version)
 	fmt.Printf("\033[32m✓\033[0m Config: %s\n", configPath)
 	fmt.Printf("\033[32m✓\033[0m Interface: %s\n", config.Interface.Address.String())
 	fmt.Printf("\033[32m✓\033[0m Peer endpoint: %s\n", config.Peers[0].Endpoint.String())

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version is set at build time using -ldflags
-var Version = "1.0.0-dev"
+var Version = "v1.0.0-dev"


### PR DESCRIPTION
This pull request introduces minor updates to improve functionality and consistency in the codebase. The changes include updates to command whitelists, version formatting, and user-facing messages.

### Command Whitelist Updates:
* [`.claude/settings.local.json`](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3L25-R27): Added `Bash(git commit:*)` and `Bash(git push:*)` to the whitelist, expanding the allowed commands for Bash.

### Version Formatting and Messaging:
* [`version.go`](diffhunk://#diff-1ef170619a70876f007d5edfc4554a81aa686eae7678b70df0347b3133cd6d14L4-R4): Updated the `Version` variable to include a "v" prefix for consistency with semantic versioning (`v1.0.0-dev`).
* `main.go`:
  - [`func printUsage()`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L19-R19): Removed the "v" prefix from the version placeholder in the ASCII art banner for better alignment with the new version format.
  - [`func main()`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L139-R139): Adjusted the startup message to match the updated version format by removing the "v" prefix in the printed message.