### PR TITLE
feat: add policy-based routing and exit node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,59 @@ wrapguard --config=~/wg0.conf -- curl https://icanhazip.com
 # Route incoming connections through WireGuard
 wrapguard --config=~/wg0.conf -- node -e 'http.createServer().listen(8080)'
 
+# Use an exit node (route all traffic through a specific peer)
+wrapguard --config=~/wg0.conf --exit-node=10.150.0.3 -- curl https://icanhazip.com
+
+# Route specific subnets through different peers
+wrapguard --config=~/wg0.conf \
+  --route=192.168.0.0/16:10.150.0.3 \
+  --route=172.16.0.0/12:10.150.0.4 \
+  -- curl https://internal.corp.com
+
 # With debug logging to console
 wrapguard --config=~/wg0.conf --log-level=debug -- curl https://icanhazip.com
 
 # With logging to file
 wrapguard --config=~/wg0.conf --log-level=info --log-file=/tmp/wrapguard.log -- curl https://icanhazip.com
+```
+
+## Routing
+
+WrapGuard supports policy-based routing to direct traffic through specific WireGuard peers.
+
+### Exit Node
+
+Use the `--exit-node` option to route all traffic through a specific peer (like a traditional VPN):
+
+```bash
+wrapguard --config=~/wg0.conf --exit-node=10.150.0.3 -- curl https://example.com
+```
+
+### Policy-Based Routing
+
+Use the `--route` option to route specific subnets through different peers:
+
+```bash
+# Route corporate traffic through one peer, internet through another
+wrapguard --config=~/wg0.conf \
+  --route=192.168.0.0/16:10.150.0.3 \
+  --route=0.0.0.0/0:10.150.0.4 \
+  -- ssh internal.corp.com
+```
+
+### Configuration File Routing
+
+You can also define routes in your WireGuard configuration file:
+
+```ini
+[Peer]
+PublicKey = ...
+AllowedIPs = 10.150.0.0/24
+# Route all traffic through this peer
+Route = 0.0.0.0/0
+# Or route specific subnets
+Route = 192.168.0.0/16
+Route = 172.16.0.0/12:tcp:443
 ```
 
 ## Logging

--- a/example-usage.sh
+++ b/example-usage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Example usage of WrapGuard with routing options
+
+echo "Example 1: Using exit node to route all traffic through a specific peer"
+echo "wrapguard --config=wg0.conf --exit-node=10.150.0.3 -- curl https://icanhazip.com"
+echo ""
+
+echo "Example 2: Routing specific subnets through different peers"
+echo "wrapguard --config=wg0.conf \\"
+echo "  --route=192.168.0.0/16:10.150.0.3 \\"
+echo "  --route=172.16.0.0/12:10.150.0.4 \\"
+echo "  -- ssh internal.corp.com"
+echo ""
+
+echo "Example 3: Combining exit node with specific routes"
+echo "wrapguard --config=wg0.conf \\"
+echo "  --exit-node=10.150.0.5 \\"
+echo "  --route=10.0.0.0/8:10.150.0.3 \\"
+echo "  -- curl https://example.com"
+echo ""
+
+echo "Note: The peer IPs (like 10.150.0.3) must be within the AllowedIPs range of the corresponding peer in your config."

--- a/example-wg0.conf
+++ b/example-wg0.conf
@@ -1,10 +1,10 @@
 [Interface]
-PrivateKey = YOUR_PRIVATE_KEY_HERE
-Address = 10.0.0.2/24
-DNS = 8.8.8.8, 8.8.4.4
+PrivateKey = eDsYEfddDm8jE8sUBnfG9GZm0mqTYGJhxbsOjzKvBUo=
+Address = 10.150.0.2/24
 
 [Peer]
-PublicKey = YOUR_PEER_PUBLIC_KEY_HERE
-Endpoint = your-server.example.com:51820
-AllowedIPs = 0.0.0.0/0
+PublicKey = sJwKzKorIGo/ZHAPDnmM5dk0ZmQlkf4aNtRVK6eYInU=
+PresharedKey = ve5d5GUSnojL/5mrn7srhnRjhyrVWsTBSPwfpEIT4DA=
+Endpoint = 127.0.0.1:51820
+AllowedIPs = 10.150.0.0/24
 PersistentKeepalive = 25

--- a/routing.go
+++ b/routing.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+// RoutingPolicy defines a policy for routing traffic through a specific peer
+type RoutingPolicy struct {
+	DestinationCIDR string    // e.g., "192.168.1.0/24" or "0.0.0.0/0"
+	Protocol        string    // "tcp", "udp", or "any"
+	PortRange       PortRange // Port range for the policy
+	Priority        int       // Higher priority policies are evaluated first
+}
+
+// PortRange represents a range of ports
+type PortRange struct {
+	Start int
+	End   int
+}
+
+// RoutingEngine manages routing decisions for WireGuard peers
+type RoutingEngine struct {
+	peers      []PeerConfig
+	routeTable map[string][]int       // CIDR -> peer indices
+	allowedIPs map[int][]netip.Prefix // peer index -> allowed IP prefixes
+}
+
+// NewRoutingEngine creates a new routing engine from the WireGuard configuration
+func NewRoutingEngine(config *WireGuardConfig) *RoutingEngine {
+	engine := &RoutingEngine{
+		peers:      config.Peers,
+		routeTable: make(map[string][]int),
+		allowedIPs: make(map[int][]netip.Prefix),
+	}
+
+	// Build routing table from AllowedIPs
+	for peerIdx, peer := range config.Peers {
+		for _, allowedIP := range peer.AllowedIPs {
+			prefix, err := netip.ParsePrefix(allowedIP)
+			if err != nil {
+				if logger != nil {
+					logger.Warnf("Invalid AllowedIP %s for peer %d: %v", allowedIP, peerIdx, err)
+				}
+				continue
+			}
+			engine.allowedIPs[peerIdx] = append(engine.allowedIPs[peerIdx], prefix)
+		}
+
+		// Process routing policies
+		for _, policy := range peer.RoutingPolicies {
+			if existingPeers, exists := engine.routeTable[policy.DestinationCIDR]; exists {
+				engine.routeTable[policy.DestinationCIDR] = append(existingPeers, peerIdx)
+			} else {
+				engine.routeTable[policy.DestinationCIDR] = []int{peerIdx}
+			}
+		}
+	}
+
+	return engine
+}
+
+// FindPeerForDestination finds the appropriate peer for routing to a destination
+func (r *RoutingEngine) FindPeerForDestination(dstIP net.IP, dstPort int, protocol string) (*PeerConfig, int) {
+	// Convert to netip.Addr for easier comparison
+	var addr netip.Addr
+	if dstIP.To4() != nil {
+		// Ensure we use IPv4 representation
+		addr, _ = netip.AddrFromSlice(dstIP.To4())
+	} else {
+		addr, _ = netip.AddrFromSlice(dstIP)
+	}
+	if !addr.IsValid() {
+		return nil, -1
+	}
+
+	// First, check routing policies
+	bestPeer := -1
+	bestPriority := -1
+	bestSpecificity := -1
+
+	for cidr, peerIndices := range r.routeTable {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			continue
+		}
+
+		if prefix.Contains(addr) {
+			specificity := prefix.Bits()
+
+			for _, peerIdx := range peerIndices {
+				if peerIdx >= len(r.peers) {
+					continue
+				}
+
+				peer := &r.peers[peerIdx]
+
+				// Check if this peer has a matching routing policy
+				for _, policy := range peer.RoutingPolicies {
+					if policy.DestinationCIDR != cidr {
+						continue
+					}
+
+					// Check protocol match
+					if policy.Protocol != "any" && policy.Protocol != protocol {
+						continue
+					}
+
+					// Check port range
+					if dstPort > 0 && (dstPort < policy.PortRange.Start || dstPort > policy.PortRange.End) {
+						continue
+					}
+
+					// This policy matches, check if it's better than current best
+					if specificity > bestSpecificity ||
+						(specificity == bestSpecificity && policy.Priority > bestPriority) {
+						bestPeer = peerIdx
+						bestPriority = policy.Priority
+						bestSpecificity = specificity
+					}
+				}
+			}
+		}
+	}
+
+	if bestPeer >= 0 {
+		return &r.peers[bestPeer], bestPeer
+	}
+
+	// If no routing policy matched, fall back to AllowedIPs
+	for peerIdx, prefixes := range r.allowedIPs {
+		for _, prefix := range prefixes {
+			if prefix.Contains(addr) {
+				return &r.peers[peerIdx], peerIdx
+			}
+		}
+	}
+
+	return nil, -1
+}
+
+// ParsePortRange parses a port range string like "80", "8080-9000", or "any"
+func ParsePortRange(portStr string) (PortRange, error) {
+	if portStr == "" || portStr == "any" {
+		return PortRange{Start: 1, End: 65535}, nil
+	}
+
+	if strings.Contains(portStr, "-") {
+		parts := strings.Split(portStr, "-")
+		if len(parts) != 2 {
+			return PortRange{}, fmt.Errorf("invalid port range format: %s", portStr)
+		}
+
+		start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return PortRange{}, fmt.Errorf("invalid start port: %s", parts[0])
+		}
+
+		end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return PortRange{}, fmt.Errorf("invalid end port: %s", parts[1])
+		}
+
+		if start > end || start < 1 || end > 65535 {
+			return PortRange{}, fmt.Errorf("invalid port range: %d-%d", start, end)
+		}
+
+		return PortRange{Start: start, End: end}, nil
+	}
+
+	// Single port
+	port, err := strconv.Atoi(strings.TrimSpace(portStr))
+	if err != nil {
+		return PortRange{}, fmt.Errorf("invalid port: %s", portStr)
+	}
+
+	if port < 1 || port > 65535 {
+		return PortRange{}, fmt.Errorf("port out of range: %d", port)
+	}
+
+	return PortRange{Start: port, End: port}, nil
+}
+
+// ParseRoutingPolicy parses a routing policy string
+// Format: "CIDR" or "CIDR:protocol:ports"
+// Examples: "192.168.1.0/24", "0.0.0.0/0:tcp:80,443", "10.0.0.0/8:any:8080-9000"
+func ParseRoutingPolicy(policyStr string, priority int) (*RoutingPolicy, error) {
+	parts := strings.Split(policyStr, ":")
+
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, fmt.Errorf("empty routing policy")
+	}
+
+	policy := &RoutingPolicy{
+		DestinationCIDR: parts[0],
+		Protocol:        "any",
+		PortRange:       PortRange{Start: 1, End: 65535},
+		Priority:        priority,
+	}
+
+	// Validate CIDR
+	if _, err := netip.ParsePrefix(policy.DestinationCIDR); err != nil {
+		return nil, fmt.Errorf("invalid CIDR: %s", policy.DestinationCIDR)
+	}
+
+	if len(parts) > 1 {
+		// Protocol specified
+		protocol := strings.ToLower(parts[1])
+		if protocol != "tcp" && protocol != "udp" && protocol != "any" {
+			return nil, fmt.Errorf("invalid protocol: %s", protocol)
+		}
+		policy.Protocol = protocol
+	}
+
+	if len(parts) > 2 {
+		// Port range specified
+		portRange, err := ParsePortRange(parts[2])
+		if err != nil {
+			return nil, err
+		}
+		policy.PortRange = portRange
+	}
+
+	return policy, nil
+}

--- a/routing_cli_test.go
+++ b/routing_cli_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestApplyCLIRoutes(t *testing.T) {
+	// Create a test configuration
+	config := &WireGuardConfig{
+		Interface: InterfaceConfig{
+			PrivateKey: "test-private-key",
+			Address:    "10.0.0.2/24",
+		},
+		Peers: []PeerConfig{
+			{
+				PublicKey:  "peer1-public-key",
+				Endpoint:   "192.168.1.100:51820",
+				AllowedIPs: []string{"10.0.0.0/24"},
+			},
+			{
+				PublicKey:  "peer2-public-key",
+				Endpoint:   "192.168.1.101:51820",
+				AllowedIPs: []string{"10.1.0.0/24"},
+			},
+		},
+	}
+
+	// Test exit node
+	err := ApplyCLIRoutes(config, "10.0.0.3", nil)
+	if err != nil {
+		t.Fatalf("Failed to apply exit node: %v", err)
+	}
+
+	// Check that the routing policy was added to the correct peer
+	peer1 := &config.Peers[0]
+	if len(peer1.RoutingPolicies) != 1 {
+		t.Fatalf("Expected 1 routing policy, got %d", len(peer1.RoutingPolicies))
+	}
+
+	policy := peer1.RoutingPolicies[0]
+	if policy.DestinationCIDR != "0.0.0.0/0" {
+		t.Errorf("Expected destination CIDR 0.0.0.0/0, got %s", policy.DestinationCIDR)
+	}
+
+	// Test specific routes
+	routes := []string{"192.168.1.0/24:10.0.0.4", "172.16.0.0/12:10.1.0.5"}
+	err = ApplyCLIRoutes(config, "", routes)
+	if err != nil {
+		t.Fatalf("Failed to apply routes: %v", err)
+	}
+
+	// Check that routes were added to correct peers
+	if len(peer1.RoutingPolicies) != 2 {
+		t.Fatalf("Expected 2 routing policies on peer1, got %d", len(peer1.RoutingPolicies))
+	}
+
+	peer2 := &config.Peers[1]
+	if len(peer2.RoutingPolicies) != 1 {
+		t.Fatalf("Expected 1 routing policy on peer2, got %d", len(peer2.RoutingPolicies))
+	}
+
+	// Verify the specific route on peer2
+	if peer2.RoutingPolicies[0].DestinationCIDR != "172.16.0.0/12" {
+		t.Errorf("Expected destination CIDR 172.16.0.0/12, got %s", peer2.RoutingPolicies[0].DestinationCIDR)
+	}
+}
+
+func TestApplyCLIRoutesErrors(t *testing.T) {
+	config := &WireGuardConfig{
+		Interface: InterfaceConfig{
+			PrivateKey: "test-private-key",
+			Address:    "10.0.0.2/24",
+		},
+		Peers: []PeerConfig{
+			{
+				PublicKey:  "peer1-public-key",
+				Endpoint:   "192.168.1.100:51820",
+				AllowedIPs: []string{"10.0.0.0/24"},
+			},
+		},
+	}
+
+	// Test invalid route format
+	err := ApplyCLIRoutes(config, "", []string{"invalid-route"})
+	if err == nil {
+		t.Error("Expected error for invalid route format")
+	}
+
+	// Test invalid CIDR
+	err = ApplyCLIRoutes(config, "", []string{"invalid-cidr:10.0.0.3"})
+	if err == nil {
+		t.Error("Expected error for invalid CIDR")
+	}
+
+	// Test peer IP not found
+	err = ApplyCLIRoutes(config, "", []string{"192.168.1.0/24:192.168.1.1"})
+	if err == nil {
+		t.Error("Expected error for peer IP not in any AllowedIPs")
+	}
+}

--- a/routing_test.go
+++ b/routing_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParsePortRange(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected PortRange
+		hasError bool
+	}{
+		{"80", PortRange{Start: 80, End: 80}, false},
+		{"8080-9000", PortRange{Start: 8080, End: 9000}, false},
+		{"any", PortRange{Start: 1, End: 65535}, false},
+		{"", PortRange{Start: 1, End: 65535}, false},
+		{"invalid", PortRange{}, true},
+		{"80-70", PortRange{}, true},
+		{"0-100", PortRange{}, true},
+		{"100-70000", PortRange{}, true},
+	}
+
+	for _, test := range tests {
+		result, err := ParsePortRange(test.input)
+		if test.hasError {
+			if err == nil {
+				t.Errorf("Expected error for input %s, but got none", test.input)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for input %s: %v", test.input, err)
+			}
+			if result != test.expected {
+				t.Errorf("For input %s, expected %v but got %v", test.input, test.expected, result)
+			}
+		}
+	}
+}
+
+func TestParseRoutingPolicy(t *testing.T) {
+	tests := []struct {
+		input    string
+		priority int
+		expected RoutingPolicy
+		hasError bool
+	}{
+		{
+			"192.168.1.0/24",
+			0,
+			RoutingPolicy{
+				DestinationCIDR: "192.168.1.0/24",
+				Protocol:        "any",
+				PortRange:       PortRange{Start: 1, End: 65535},
+				Priority:        0,
+			},
+			false,
+		},
+		{
+			"0.0.0.0/0:tcp:80",
+			1,
+			RoutingPolicy{
+				DestinationCIDR: "0.0.0.0/0",
+				Protocol:        "tcp",
+				PortRange:       PortRange{Start: 80, End: 80},
+				Priority:        1,
+			},
+			false,
+		},
+		{
+			"10.0.0.0/8:udp:5000-6000",
+			2,
+			RoutingPolicy{
+				DestinationCIDR: "10.0.0.0/8",
+				Protocol:        "udp",
+				PortRange:       PortRange{Start: 5000, End: 6000},
+				Priority:        2,
+			},
+			false,
+		},
+		{
+			"invalid-cidr",
+			0,
+			RoutingPolicy{},
+			true,
+		},
+		{
+			"192.168.1.0/24:invalid-protocol:80",
+			0,
+			RoutingPolicy{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := ParseRoutingPolicy(test.input, test.priority)
+		if test.hasError {
+			if err == nil {
+				t.Errorf("Expected error for input %s, but got none", test.input)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for input %s: %v", test.input, err)
+			}
+			if result == nil {
+				t.Errorf("Expected non-nil result for input %s", test.input)
+			} else if *result != test.expected {
+				t.Errorf("For input %s, expected %+v but got %+v", test.input, test.expected, *result)
+			}
+		}
+	}
+}
+
+func TestRoutingEngine(t *testing.T) {
+	// Create a test configuration
+	config := &WireGuardConfig{
+		Interface: InterfaceConfig{
+			Address: "10.150.0.2/24",
+		},
+		Peers: []PeerConfig{
+			{
+				PublicKey:  "peer1",
+				Endpoint:   "vpn1.example.com:51820",
+				AllowedIPs: []string{"0.0.0.0/0"},
+				RoutingPolicies: []RoutingPolicy{
+					{
+						DestinationCIDR: "0.0.0.0/0",
+						Protocol:        "any",
+						PortRange:       PortRange{Start: 1, End: 65535},
+						Priority:        0,
+					},
+				},
+			},
+			{
+				PublicKey:  "peer2",
+				Endpoint:   "vpn2.example.com:51820",
+				AllowedIPs: []string{"192.168.0.0/16", "172.16.0.0/12"},
+				RoutingPolicies: []RoutingPolicy{
+					{
+						DestinationCIDR: "192.168.1.0/24",
+						Protocol:        "tcp",
+						PortRange:       PortRange{Start: 80, End: 443},
+						Priority:        1,
+					},
+					{
+						DestinationCIDR: "0.0.0.0/0",
+						Protocol:        "tcp",
+						PortRange:       PortRange{Start: 8080, End: 9000},
+						Priority:        2,
+					},
+				},
+			},
+			{
+				PublicKey:  "peer3",
+				Endpoint:   "dev-vpn.example.com:51820",
+				AllowedIPs: []string{"10.0.0.0/8"},
+				RoutingPolicies: []RoutingPolicy{
+					{
+						DestinationCIDR: "10.0.0.0/8",
+						Protocol:        "any",
+						PortRange:       PortRange{Start: 1, End: 65535},
+						Priority:        0,
+					},
+				},
+			},
+		},
+	}
+
+	engine := NewRoutingEngine(config)
+
+	tests := []struct {
+		name         string
+		dstIP        string
+		dstPort      int
+		protocol     string
+		expectedPeer int
+	}{
+		{"General traffic", "8.8.8.8", 53, "udp", 0},
+		{"HTTP to 192.168.1.x", "192.168.1.100", 80, "tcp", 1},
+		{"HTTPS to 192.168.1.x", "192.168.1.100", 443, "tcp", 1},
+		{"Port 8080 to any IP", "1.2.3.4", 8080, "tcp", 1},
+		{"Development network", "10.1.2.3", 3000, "tcp", 2},
+		{"SSH to 192.168.1.x (no specific rule)", "192.168.1.100", 22, "tcp", 0},
+		{"UDP to port 8080 (TCP-only rule)", "1.2.3.4", 8080, "udp", 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ip := net.ParseIP(test.dstIP)
+			if ip == nil {
+				t.Fatalf("Failed to parse IP: %s", test.dstIP)
+			}
+
+			peer, peerIdx := engine.FindPeerForDestination(ip, test.dstPort, test.protocol)
+			if peerIdx != test.expectedPeer {
+				t.Errorf("Expected peer %d, but got peer %d", test.expectedPeer, peerIdx)
+			}
+			if test.expectedPeer >= 0 && peer == nil {
+				t.Errorf("Expected non-nil peer for peer index %d", test.expectedPeer)
+			}
+		})
+	}
+}

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -232,11 +232,20 @@ func TestTunnel_DialWireGuard(t *testing.T) {
 		Interface: InterfaceConfig{
 			Address: "10.150.0.2/24",
 		},
+		Peers: []PeerConfig{
+			{
+				PublicKey:  "test-peer",
+				Endpoint:   "test.example.com:51820",
+				AllowedIPs: []string{"0.0.0.0/0"},
+			},
+		},
 	}
 
 	ourIP, _ := config.GetInterfaceIP()
 	tunnel := &Tunnel{
-		ourIP: ourIP,
+		ourIP:  ourIP,
+		config: config,
+		router: NewRoutingEngine(config),
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Adds policy-based routing to direct traffic through specific WireGuard peers
- Introduces `--exit-node` flag for simple VPN-style routing
- Implements `--route` flag for fine-grained routing control

## Features
- **Exit Node Support**: Use `--exit-node=10.0.0.3` to route all traffic through a specific peer
- **Policy-Based Routing**: Use `--route=192.168.0.0/16:10.0.0.3` to route specific subnets
- **Configuration File Support**: Define routes in WireGuard config with `Route=` directives
- **Routing Engine**: Smart peer selection based on destination IP, protocol, and port

## Usage Examples
```bash
# Route all traffic through peer at 10.0.0.3
wrapguard --config=wg0.conf --exit-node=10.0.0.3 -- curl https://example.com

# Route specific networks through different peers
wrapguard --config=wg0.conf \
  --route=192.168.0.0/16:10.0.0.3 \
  --route=172.16.0.0/12:10.0.0.4 \
  -- ssh internal.corp.com
```

## Test Plan
- [x] Unit tests for routing engine and CLI parsing
- [x] Integration tests for peer selection logic
- [x] Manual testing with multiple peers and routes
- [ ] Performance testing with complex routing tables