### PR TITLE
fix: address main and release workflow regressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,12 @@ jobs:
         test -f "$verify_dir/libwrapguard.so"
         test -f "$verify_dir/README.md"
         test -f "$verify_dir/example-wg0.conf"
-        "$verify_dir/wrapguard" --version
-        "$verify_dir/wrapguard" --help
+        if [ "${{ matrix.arch }}" = "amd64" ]; then
+          "$verify_dir/wrapguard" --version
+          "$verify_dir/wrapguard" --help
+        else
+          file "$verify_dir/wrapguard" | grep -qi "aarch64\\|arm64"
+        fi
 
     - name: Generate checksum
       run: |

--- a/packaging_regression_test.go
+++ b/packaging_regression_test.go
@@ -31,6 +31,34 @@ func TestReleaseWorkflowPackagesExpectedMacOSArtifacts(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowValidatesLinuxArm64ArchivesWithoutExecutingBinary(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatalf("failed to read release workflow: %v", err)
+	}
+
+	content := string(data)
+	requiredSnippets := []string{
+		`archive="wrapguard-${{ github.event.release.tag_name }}-linux-${{ matrix.arch }}.tar.gz"`,
+		`if [ "${{ matrix.arch }}" = "amd64" ]; then`,
+		`"$verify_dir/wrapguard" --version`,
+		`"$verify_dir/wrapguard" --help`,
+		`file "$verify_dir/wrapguard" | grep -qi "aarch64\\|arm64"`,
+	}
+
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("release workflow missing required Linux validation snippet: %q", snippet)
+		}
+	}
+
+	forbiddenSnippet := `if [ "${{ matrix.arch }}" = "arm64" ]; then
+          "$verify_dir/wrapguard" --version`
+	if strings.Contains(content, forbiddenSnippet) {
+		t.Fatalf("release workflow should not execute the Linux arm64 binary during archive validation")
+	}
+}
+
 func TestSmokeMacOSTargetValidatesExpectedRuntimeArtifacts(t *testing.T) {
 	data, err := os.ReadFile("Makefile")
 	if err != nil {

--- a/runtime_helpers_test.go
+++ b/runtime_helpers_test.go
@@ -1134,12 +1134,15 @@ func TestRunSelfTestSucceedsWithInjectedProbe(t *testing.T) {
 		"Self-test check passed: IPC socket is reachable",
 		"Self-test check passed: SOCKS listener is reachable",
 		"Self-test check passed: interceptor READY",
-		"Self-test check passed: intercepted outbound connect",
 		"Self-test completed successfully",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("runSelfTest output missing %q: %q", want, got)
 		}
+	}
+	if !strings.Contains(got, "Self-test check passed: intercepted outbound connect") &&
+		!strings.Contains(got, "Self-test check passed: SOCKS server observed intercepted outbound connect") {
+		t.Fatalf("runSelfTest output missing outbound connect confirmation: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept the updated macOS self-test success signal after the merged interceptor changes so the post-merge `Tests` workflow stops failing on `main`
- validate Linux arm64 release archives by checking binary architecture instead of trying to execute an arm64 binary on an amd64 GitHub runner
- add regression coverage for the Linux arm64 release validation path so this release break is caught in repo tests next time

## Testing
- `go test -v ./...`
- `go test -v -race -run TestRunSelfTestSucceedsWithInjectedProbe -count=1 -timeout 45s ./...`
- `go test -v -race -run TestRunSelfTestFailsWhenConnectNeverArrives -count=1 -timeout 45s ./...`
- `go test -v -race -coverprofile=coverage.out -timeout 4m ./...`

## Follow-up
- `v1.3.2` was cut from the broken commit on `main`, so ship a fresh release after this merges instead of reusing that tag
